### PR TITLE
Add typed Supabase CRUD helpers for inventory_units

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -1,0 +1,98 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import { createClient } from '@/lib/supabase/client';
+import AddItemModal from '@/components/AddItemModal';
+
+type Item = { id: string; name: string; quantity: number; expiration_date: string | null };
+
+export default function DashboardPage() {
+  const supabase = createClient();
+
+  const [kitchenId, setKitchenId] = useState<string | null>(null);
+  const [items, setItems] = useState<Item[]>([]);
+  const [units, setUnits] = useState<{ id: string | number; name: string }[]>([]);
+  const [locations, setLocations] = useState<{ id: string | number; name: string }[]>([]);
+  const [open, setOpen] = useState(false);
+
+  // 1) Resolve active kitchen from profile
+  const resolveKitchen = useCallback(async () => {
+    const { data: auth } = await supabase.auth.getUser();
+    const uid = auth.user?.id;
+    if (!uid) return;
+
+    const { data: profile } = await supabase
+      .from('profiles')
+      .select('default_kitchen_id')
+      .eq('id', uid)
+      .single();
+
+    if (profile?.default_kitchen_id) setKitchenId(profile.default_kitchen_id);
+  }, [supabase]);
+
+  // 2) Load reference data + items
+  const loadRefs = useCallback(async () => {
+    const [{ data: u }, { data: l }] = await Promise.all([
+      supabase.from('inventory_units').select('id,name').order('name'),
+      supabase.from('locations').select('id,name').order('name'),
+    ]);
+    setUnits(u ?? []);
+    setLocations(l ?? []);
+  }, [supabase]);
+
+  const loadItems = useCallback(async (kId: string) => {
+    const { data } = await supabase
+      .from('items')
+      .select('id,name,quantity,expiration_date')
+      .eq('kitchen_id', kId)
+      .order('expiration_date', { ascending: true, nullsFirst: true });
+    setItems(data ?? []);
+  }, [supabase]);
+
+  useEffect(() => {
+    resolveKitchen();
+    loadRefs();
+  }, [resolveKitchen, loadRefs]);
+
+  useEffect(() => {
+    if (kitchenId) loadItems(kitchenId);
+  }, [kitchenId, loadItems]);
+
+  return (
+    <div className="p-6 space-y-4">
+      <div className="flex items-center justify-between">
+        <h1 className="text-2xl font-semibold">Inventory</h1>
+        <button
+          onClick={() => setOpen(true)}
+          className="rounded-xl bg-black px-4 py-2 text-white"
+          disabled={!kitchenId}
+        >
+          + Add Item
+        </button>
+      </div>
+
+      <ul className="divide-y rounded-xl border">
+        {items.map(it => (
+          <li key={it.id} className="flex items-center justify-between p-3">
+            <div>
+              <div className="font-medium">{it.name}</div>
+              <div className="text-sm text-gray-600">
+                Qty: {it.quantity} • Exp: {it.expiration_date ?? '—'}
+              </div>
+            </div>
+          </li>
+        ))}
+        {items.length === 0 && <li className="p-4 text-sm text-gray-500">No items yet.</li>}
+      </ul>
+
+      <AddItemModal
+        open={open}
+        onClose={() => setOpen(false)}
+        kitchenId={kitchenId ?? ''}     // safe because button disables until ready
+        units={units}
+        locations={locations}
+        onCreated={() => kitchenId && loadItems(kitchenId)}
+      />
+    </div>
+  );
+}

--- a/components/AddItemModal.tsx
+++ b/components/AddItemModal.tsx
@@ -1,0 +1,128 @@
+"use client";
+
+import React, { useState } from "react";
+import { createClient } from "@/lib/supabase/client";
+
+type Option = { id: string | number; name: string };
+
+type Props = {
+  open: boolean;
+  onClose: () => void;
+  kitchenId: string;
+  units: Option[];
+  locations: Option[];
+  onCreated?: () => void;
+};
+
+export default function AddItemModal({ open, onClose, kitchenId, units, locations, onCreated }: Props) {
+  const supabase = createClient();
+
+  const [form, setForm] = useState({
+    name: "",
+    quantity: 1,
+    unit_id: "" as string | number | "",
+    location_id: "" as string | number | "",
+    expiration_date: "",
+    notes: "",
+  });
+  const [loading, setLoading] = useState(false);
+  const [err, setErr] = useState<string | null>(null);
+
+  if (!open) return null;
+
+  const update = (k: keyof typeof form, v: unknown) => setForm((f) => ({ ...f, [k]: v }));
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setErr(null);
+    setLoading(true);
+    try {
+      const payload = {
+        kitchen_id: kitchenId,
+        name: form.name.trim(),
+        quantity: Number(form.quantity) || 0,
+        unit_id: form.unit_id || null,
+        location_id: form.location_id || null,
+        expiration_date: form.expiration_date || null,
+        notes: form.notes || null,
+      };
+      const { error } = await supabase.from("items").insert(payload);
+      if (error) throw error;
+
+      onCreated?.();
+      onClose();
+      setForm({ name: "", quantity: 1, unit_id: "", location_id: "", expiration_date: "", notes: "" });
+    } catch (e: any) {
+      setErr(e.message ?? "Failed to add item");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 grid place-items-center bg-black/40">
+      <div className="w-full max-w-lg rounded-2xl bg-white p-6 shadow-lg">
+        <div className="mb-4 flex items-center justify-between">
+          <h2 className="text-xl font-semibold">Add Item</h2>
+          <button onClick={onClose} className="rounded px-2 py-1">
+            ✕
+          </button>
+        </div>
+
+        <form onSubmit={handleSubmit} className="grid gap-3">
+          <label className="grid gap-1">
+            <span className="text-sm">Name</span>
+            <input required className="rounded border p-2" placeholder="Milk" value={form.name} onChange={(e) => update("name", e.target.value)} />
+          </label>
+
+          <div className="grid grid-cols-2 gap-3">
+            <label className="grid gap-1">
+              <span className="text-sm">Quantity</span>
+              <input className="rounded border p-2" type="number" min={0} value={String(form.quantity)} onChange={(e) => update("quantity", Number(e.target.value))} />
+            </label>
+
+            <label className="grid gap-1">
+              <span className="text-sm">Unit</span>
+              <select className="rounded border p-2" value={String(form.unit_id)} onChange={(e) => update("unit_id", e.target.value)}>
+                <option value="">—</option>
+                {units.map((u) => (
+                  <option key={String(u.id)} value={String(u.id)}>
+                    {u.name}
+                  </option>
+                ))}
+              </select>
+            </label>
+          </div>
+
+          <label className="grid gap-1">
+            <span className="text-sm">Location</span>
+            <select className="rounded border p-2" value={String(form.location_id)} onChange={(e) => update("location_id", e.target.value)}>
+              <option value="">—</option>
+              {locations.map((l) => (
+                <option key={String(l.id)} value={String(l.id)}>
+                  {l.name}
+                </option>
+              ))}
+            </select>
+          </label>
+
+          <label className="grid gap-1">
+            <span className="text-sm">Expiration date</span>
+            <input className="rounded border p-2" type="date" value={form.expiration_date} onChange={(e) => update("expiration_date", e.target.value)} />
+          </label>
+
+          <label className="grid gap-1">
+            <span className="text-sm">Notes</span>
+            <textarea className="rounded border p-2" rows={3} placeholder="Brand, size, etc." value={form.notes} onChange={(e) => update("notes", e.target.value)} />
+          </label>
+
+          {err && <p className="text-sm text-red-600">{err}</p>}
+
+          <button className="mt-2 rounded-xl border bg-black px-4 py-2 text-white disabled:opacity-60" type="submit" disabled={loading}>
+            {loading ? "Adding…" : "Add Item"}
+          </button>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/lib/supabase/inventory.ts
+++ b/lib/supabase/inventory.ts
@@ -1,0 +1,111 @@
+import type { PostgrestError, SupabaseClient } from "@supabase/supabase-js";
+
+import { createServiceRoleClient } from "./service-role";
+
+type InventoryUnitRow = {
+  id: string;
+  kitchen_id: string | null;
+  location_id: string | null;
+  item_id: string | null;
+  quantity: number | string | null;
+  uom: string | null;
+  expires_at: string | null;
+  created_at: string | null;
+  updated_at: string | null;
+};
+
+export type NewInventoryUnit = {
+  kitchen_id: string;
+  location_id?: string | null;
+  item_id: string | null;
+  quantity?: number | string | null;
+  uom?: string | null;
+  expires_at?: string | null;
+};
+
+export type UpdateInventoryUnit = Partial<NewInventoryUnit> & { id: string };
+
+function handleError(error: PostgrestError | null): never | void {
+  if (error) throw error;
+}
+
+/**
+ * Create an inventory unit using the provided Supabase client (RLS applies).
+ */
+export async function createInventoryUnit(
+  supabase: SupabaseClient,
+  payload: NewInventoryUnit,
+): Promise<InventoryUnitRow> {
+  const { data, error } = await supabase.from("inventory_units").insert(payload).select().maybeSingle();
+  handleError(error);
+  if (!data) throw new Error("Failed to create inventory unit");
+  return data as InventoryUnitRow;
+}
+
+/**
+ * Create an inventory unit using the service role (bypasses RLS). Useful for admin tasks.
+ */
+export async function createInventoryUnitAdmin(payload: NewInventoryUnit): Promise<InventoryUnitRow> {
+  const admin = createServiceRoleClient();
+  const { data, error } = await admin.from("inventory_units").insert(payload).select().maybeSingle();
+  handleError(error);
+  if (!data) throw new Error("Failed to create inventory unit (admin)");
+  return data as InventoryUnitRow;
+}
+
+export async function getInventoryUnit(
+  supabase: SupabaseClient,
+  id: string,
+): Promise<InventoryUnitRow | null> {
+  const { data, error } = await supabase.from("inventory_units").select("*").eq("id", id).maybeSingle();
+  handleError(error);
+  return (data as InventoryUnitRow) ?? null;
+}
+
+export async function listInventoryUnits(
+  supabase: SupabaseClient,
+  kitchenId: string,
+  opts?: { limit?: number; offset?: number; order?: { column: string; ascending?: boolean } },
+): Promise<InventoryUnitRow[]> {
+  let query = supabase.from("inventory_units").select("*").eq("kitchen_id", kitchenId);
+  if (opts?.order) query = query.order(opts.order.column, { ascending: opts.order.ascending ?? true });
+  if (opts?.limit) query = query.limit(opts.limit);
+  if (opts?.offset) query = query.range(opts.offset, (opts.offset ?? 0) + (opts.limit ?? 100) - 1);
+  const { data, error } = await query;
+  handleError(error);
+  return (data as InventoryUnitRow[]) ?? [];
+}
+
+export async function updateInventoryUnit(
+  supabase: SupabaseClient,
+  payload: UpdateInventoryUnit,
+): Promise<InventoryUnitRow> {
+  const { id, ...rest } = payload;
+  const { data, error } = await supabase.from("inventory_units").update(rest).eq("id", id).select().maybeSingle();
+  handleError(error);
+  if (!data) throw new Error("Failed to update inventory unit");
+  return data as InventoryUnitRow;
+}
+
+export async function deleteInventoryUnit(
+  supabase: SupabaseClient,
+  id: string,
+): Promise<boolean> {
+  const { error } = await supabase.from("inventory_units").delete().eq("id", id);
+  handleError(error);
+  return true;
+}
+
+/**
+ * Reconcile a unit quantity (idempotent - sets quantity to provided value).
+ */
+export async function reconcileInventoryUnit(
+  supabase: SupabaseClient,
+  id: string,
+  quantity: number | string | null,
+): Promise<InventoryUnitRow> {
+  const { data, error } = await supabase.from("inventory_units").update({ quantity }).eq("id", id).select().maybeSingle();
+  handleError(error);
+  if (!data) throw new Error("Failed to reconcile inventory unit");
+  return data as InventoryUnitRow;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,7 @@
   "packages": {
     "": {
       "dependencies": {
-        "@aws-sdk/client-s3": "^3.929.0",
+        "@aws-sdk/client-s3": "^3.934.0",
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/modifiers": "^9.0.0",
         "@dnd-kit/sortable": "^10.0.0",
@@ -111,6 +111,7 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/@aws-crypto/crc32c/-/crc32c-5.2.0.tgz",
       "integrity": "sha512-+iWb8qaHLYKrNvGRbiYRHSdKRWhto5XlZUEBwDjYNf+ly5SVYG6zEoYIdxvf5R3zyeP16w4PLBn3rH1xc74Rag==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/util": "^5.2.0",
         "@aws-sdk/types": "^3.222.0",
@@ -169,6 +170,7 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
       "integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-js": "^5.2.0",
         "@aws-crypto/supports-web-crypto": "^5.2.0",
@@ -183,6 +185,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
       "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+      "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
       },
@@ -194,6 +197,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
       "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@smithy/is-array-buffer": "^2.2.0",
         "tslib": "^2.6.2"
@@ -206,6 +210,7 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
       "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@smithy/util-buffer-from": "^2.2.0",
         "tslib": "^2.6.2"
@@ -218,6 +223,7 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
       "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/util": "^5.2.0",
         "@aws-sdk/types": "^3.222.0",
@@ -281,66 +287,65 @@
       }
     },
     "node_modules/@aws-sdk/client-s3": {
-      "version": "3.929.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.929.0.tgz",
-      "integrity": "sha512-M6G+1CBTowN+m0Jrww5/AXMqlk4nIJqwaa/vOw+EbvLD7ROpBs6bStSai9esP9PkIVW6KMu4zCIgHzKhGa3R2A==",
+      "version": "3.934.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.934.0.tgz",
+      "integrity": "sha512-dtg77FGTgt8WlqgrRriCOie/SUl0x0cx2itPgK6fkf3pRK0t1betQ0EUZM6VYQcj+hqVMzh/XRcr1TDm5n5eVw==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha1-browser": "5.2.0",
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "3.928.0",
-        "@aws-sdk/credential-provider-node": "3.929.0",
-        "@aws-sdk/middleware-bucket-endpoint": "3.922.0",
-        "@aws-sdk/middleware-expect-continue": "3.922.0",
-        "@aws-sdk/middleware-flexible-checksums": "3.928.0",
-        "@aws-sdk/middleware-host-header": "3.922.0",
-        "@aws-sdk/middleware-location-constraint": "3.922.0",
-        "@aws-sdk/middleware-logger": "3.922.0",
-        "@aws-sdk/middleware-recursion-detection": "3.922.0",
-        "@aws-sdk/middleware-sdk-s3": "3.928.0",
-        "@aws-sdk/middleware-ssec": "3.922.0",
-        "@aws-sdk/middleware-user-agent": "3.928.0",
-        "@aws-sdk/region-config-resolver": "3.925.0",
-        "@aws-sdk/signature-v4-multi-region": "3.928.0",
-        "@aws-sdk/types": "3.922.0",
-        "@aws-sdk/util-endpoints": "3.922.0",
-        "@aws-sdk/util-user-agent-browser": "3.922.0",
-        "@aws-sdk/util-user-agent-node": "3.928.0",
-        "@aws-sdk/xml-builder": "3.921.0",
-        "@smithy/config-resolver": "^4.4.2",
-        "@smithy/core": "^3.17.2",
-        "@smithy/eventstream-serde-browser": "^4.2.4",
-        "@smithy/eventstream-serde-config-resolver": "^4.3.4",
-        "@smithy/eventstream-serde-node": "^4.2.4",
-        "@smithy/fetch-http-handler": "^5.3.5",
-        "@smithy/hash-blob-browser": "^4.2.5",
-        "@smithy/hash-node": "^4.2.4",
-        "@smithy/hash-stream-node": "^4.2.4",
-        "@smithy/invalid-dependency": "^4.2.4",
-        "@smithy/md5-js": "^4.2.4",
-        "@smithy/middleware-content-length": "^4.2.4",
-        "@smithy/middleware-endpoint": "^4.3.6",
-        "@smithy/middleware-retry": "^4.4.6",
-        "@smithy/middleware-serde": "^4.2.4",
-        "@smithy/middleware-stack": "^4.2.4",
-        "@smithy/node-config-provider": "^4.3.4",
-        "@smithy/node-http-handler": "^4.4.4",
-        "@smithy/protocol-http": "^5.3.4",
-        "@smithy/smithy-client": "^4.9.2",
-        "@smithy/types": "^4.8.1",
-        "@smithy/url-parser": "^4.2.4",
+        "@aws-sdk/core": "3.934.0",
+        "@aws-sdk/credential-provider-node": "3.934.0",
+        "@aws-sdk/middleware-bucket-endpoint": "3.930.0",
+        "@aws-sdk/middleware-expect-continue": "3.930.0",
+        "@aws-sdk/middleware-flexible-checksums": "3.934.0",
+        "@aws-sdk/middleware-host-header": "3.930.0",
+        "@aws-sdk/middleware-location-constraint": "3.930.0",
+        "@aws-sdk/middleware-logger": "3.930.0",
+        "@aws-sdk/middleware-recursion-detection": "3.933.0",
+        "@aws-sdk/middleware-sdk-s3": "3.934.0",
+        "@aws-sdk/middleware-ssec": "3.930.0",
+        "@aws-sdk/middleware-user-agent": "3.934.0",
+        "@aws-sdk/region-config-resolver": "3.930.0",
+        "@aws-sdk/signature-v4-multi-region": "3.934.0",
+        "@aws-sdk/types": "3.930.0",
+        "@aws-sdk/util-endpoints": "3.930.0",
+        "@aws-sdk/util-user-agent-browser": "3.930.0",
+        "@aws-sdk/util-user-agent-node": "3.934.0",
+        "@smithy/config-resolver": "^4.4.3",
+        "@smithy/core": "^3.18.2",
+        "@smithy/eventstream-serde-browser": "^4.2.5",
+        "@smithy/eventstream-serde-config-resolver": "^4.3.5",
+        "@smithy/eventstream-serde-node": "^4.2.5",
+        "@smithy/fetch-http-handler": "^5.3.6",
+        "@smithy/hash-blob-browser": "^4.2.6",
+        "@smithy/hash-node": "^4.2.5",
+        "@smithy/hash-stream-node": "^4.2.5",
+        "@smithy/invalid-dependency": "^4.2.5",
+        "@smithy/md5-js": "^4.2.5",
+        "@smithy/middleware-content-length": "^4.2.5",
+        "@smithy/middleware-endpoint": "^4.3.9",
+        "@smithy/middleware-retry": "^4.4.9",
+        "@smithy/middleware-serde": "^4.2.5",
+        "@smithy/middleware-stack": "^4.2.5",
+        "@smithy/node-config-provider": "^4.3.5",
+        "@smithy/node-http-handler": "^4.4.5",
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/smithy-client": "^4.9.5",
+        "@smithy/types": "^4.9.0",
+        "@smithy/url-parser": "^4.2.5",
         "@smithy/util-base64": "^4.3.0",
         "@smithy/util-body-length-browser": "^4.2.0",
         "@smithy/util-body-length-node": "^4.2.1",
-        "@smithy/util-defaults-mode-browser": "^4.3.5",
-        "@smithy/util-defaults-mode-node": "^4.2.8",
-        "@smithy/util-endpoints": "^3.2.4",
-        "@smithy/util-middleware": "^4.2.4",
-        "@smithy/util-retry": "^4.2.4",
-        "@smithy/util-stream": "^4.5.5",
+        "@smithy/util-defaults-mode-browser": "^4.3.8",
+        "@smithy/util-defaults-mode-node": "^4.2.11",
+        "@smithy/util-endpoints": "^3.2.5",
+        "@smithy/util-middleware": "^4.2.5",
+        "@smithy/util-retry": "^4.2.5",
+        "@smithy/util-stream": "^4.5.6",
         "@smithy/util-utf8": "^4.2.0",
-        "@smithy/util-waiter": "^4.2.4",
-        "@smithy/uuid": "^1.1.0",
+        "@smithy/util-waiter": "^4.2.5",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -348,46 +353,47 @@
       }
     },
     "node_modules/@aws-sdk/client-sso": {
-      "version": "3.929.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.929.0.tgz",
-      "integrity": "sha512-CE1T7PvN2MDRCw96BTUz2Zcnb6Lae3Dl4w3TPB5auBv2sAiIPbQegFUwT2C8teMDGCNXyndzoTvAd4wmO9AcpA==",
+      "version": "3.934.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.934.0.tgz",
+      "integrity": "sha512-gsgJevqhY0j3x014ejhXtHLCA6o83FYm3rJoZG7tqoy3DnWerLv/FHaAnHI/+Q+csadqjoFkWGQTOedPoOunzA==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "3.928.0",
-        "@aws-sdk/middleware-host-header": "3.922.0",
-        "@aws-sdk/middleware-logger": "3.922.0",
-        "@aws-sdk/middleware-recursion-detection": "3.922.0",
-        "@aws-sdk/middleware-user-agent": "3.928.0",
-        "@aws-sdk/region-config-resolver": "3.925.0",
-        "@aws-sdk/types": "3.922.0",
-        "@aws-sdk/util-endpoints": "3.922.0",
-        "@aws-sdk/util-user-agent-browser": "3.922.0",
-        "@aws-sdk/util-user-agent-node": "3.928.0",
-        "@smithy/config-resolver": "^4.4.2",
-        "@smithy/core": "^3.17.2",
-        "@smithy/fetch-http-handler": "^5.3.5",
-        "@smithy/hash-node": "^4.2.4",
-        "@smithy/invalid-dependency": "^4.2.4",
-        "@smithy/middleware-content-length": "^4.2.4",
-        "@smithy/middleware-endpoint": "^4.3.6",
-        "@smithy/middleware-retry": "^4.4.6",
-        "@smithy/middleware-serde": "^4.2.4",
-        "@smithy/middleware-stack": "^4.2.4",
-        "@smithy/node-config-provider": "^4.3.4",
-        "@smithy/node-http-handler": "^4.4.4",
-        "@smithy/protocol-http": "^5.3.4",
-        "@smithy/smithy-client": "^4.9.2",
-        "@smithy/types": "^4.8.1",
-        "@smithy/url-parser": "^4.2.4",
+        "@aws-sdk/core": "3.934.0",
+        "@aws-sdk/middleware-host-header": "3.930.0",
+        "@aws-sdk/middleware-logger": "3.930.0",
+        "@aws-sdk/middleware-recursion-detection": "3.933.0",
+        "@aws-sdk/middleware-user-agent": "3.934.0",
+        "@aws-sdk/region-config-resolver": "3.930.0",
+        "@aws-sdk/types": "3.930.0",
+        "@aws-sdk/util-endpoints": "3.930.0",
+        "@aws-sdk/util-user-agent-browser": "3.930.0",
+        "@aws-sdk/util-user-agent-node": "3.934.0",
+        "@smithy/config-resolver": "^4.4.3",
+        "@smithy/core": "^3.18.2",
+        "@smithy/fetch-http-handler": "^5.3.6",
+        "@smithy/hash-node": "^4.2.5",
+        "@smithy/invalid-dependency": "^4.2.5",
+        "@smithy/middleware-content-length": "^4.2.5",
+        "@smithy/middleware-endpoint": "^4.3.9",
+        "@smithy/middleware-retry": "^4.4.9",
+        "@smithy/middleware-serde": "^4.2.5",
+        "@smithy/middleware-stack": "^4.2.5",
+        "@smithy/node-config-provider": "^4.3.5",
+        "@smithy/node-http-handler": "^4.4.5",
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/smithy-client": "^4.9.5",
+        "@smithy/types": "^4.9.0",
+        "@smithy/url-parser": "^4.2.5",
         "@smithy/util-base64": "^4.3.0",
         "@smithy/util-body-length-browser": "^4.2.0",
         "@smithy/util-body-length-node": "^4.2.1",
-        "@smithy/util-defaults-mode-browser": "^4.3.5",
-        "@smithy/util-defaults-mode-node": "^4.2.8",
-        "@smithy/util-endpoints": "^3.2.4",
-        "@smithy/util-middleware": "^4.2.4",
-        "@smithy/util-retry": "^4.2.4",
+        "@smithy/util-defaults-mode-browser": "^4.3.8",
+        "@smithy/util-defaults-mode-node": "^4.2.11",
+        "@smithy/util-endpoints": "^3.2.5",
+        "@smithy/util-middleware": "^4.2.5",
+        "@smithy/util-retry": "^4.2.5",
         "@smithy/util-utf8": "^4.2.0",
         "tslib": "^2.6.2"
       },
@@ -396,21 +402,22 @@
       }
     },
     "node_modules/@aws-sdk/core": {
-      "version": "3.928.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.928.0.tgz",
-      "integrity": "sha512-e28J2uKjy2uub4u41dNnmzAu0AN3FGB+LRcLN2Qnwl9Oq3kIcByl5sM8ZD+vWpNG+SFUrUasBCq8cMnHxwXZ4w==",
+      "version": "3.934.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.934.0.tgz",
+      "integrity": "sha512-b6k916ZxSrBwQPzeirncTIQXGnhps0HFOUakFt0ZEzjksePYUiEoU/SQ7VeY1j9JeAdJ24ejqddCiyLt99/3lg==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "3.922.0",
-        "@aws-sdk/xml-builder": "3.921.0",
-        "@smithy/core": "^3.17.2",
-        "@smithy/node-config-provider": "^4.3.4",
-        "@smithy/property-provider": "^4.2.4",
-        "@smithy/protocol-http": "^5.3.4",
-        "@smithy/signature-v4": "^5.3.4",
-        "@smithy/smithy-client": "^4.9.2",
-        "@smithy/types": "^4.8.1",
+        "@aws-sdk/types": "3.930.0",
+        "@aws-sdk/xml-builder": "3.930.0",
+        "@smithy/core": "^3.18.2",
+        "@smithy/node-config-provider": "^4.3.5",
+        "@smithy/property-provider": "^4.2.5",
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/signature-v4": "^5.3.5",
+        "@smithy/smithy-client": "^4.9.5",
+        "@smithy/types": "^4.9.0",
         "@smithy/util-base64": "^4.3.0",
-        "@smithy/util-middleware": "^4.2.4",
+        "@smithy/util-middleware": "^4.2.5",
         "@smithy/util-utf8": "^4.2.0",
         "tslib": "^2.6.2"
       },
@@ -419,14 +426,15 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.928.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.928.0.tgz",
-      "integrity": "sha512-tB8F9Ti0/NFyFVQX8UQtgRik88evtHpyT6WfXOB4bAY6lEnEHA0ubJZmk9y+aUeoE+OsGLx70dC3JUsiiCPJkQ==",
+      "version": "3.934.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.934.0.tgz",
+      "integrity": "sha512-bnpIGYm7Jy46dxZa1cxMQ1sF0n2iBIT+TpOPHK51sz1N2dYOicUVWUHMDgU2xIFOVcKaqV+GV4VyicMmvDBcBQ==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "3.928.0",
-        "@aws-sdk/types": "3.922.0",
-        "@smithy/property-provider": "^4.2.4",
-        "@smithy/types": "^4.8.1",
+        "@aws-sdk/core": "3.934.0",
+        "@aws-sdk/types": "3.930.0",
+        "@smithy/property-provider": "^4.2.5",
+        "@smithy/types": "^4.9.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -434,19 +442,20 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-http": {
-      "version": "3.928.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.928.0.tgz",
-      "integrity": "sha512-67ynC/8UW9Y8Gn1ZZtC3OgcQDGWrJelHmkbgpmmxYUrzVhp+NINtz3wiTzrrBFhPH/8Uy6BxvhMfXhn0ptcMEQ==",
+      "version": "3.934.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.934.0.tgz",
+      "integrity": "sha512-WJcfFik7MPIgjE8lmuDcCqddHKRMpifzoBzTZWqUJJWYXIy0rDfNzt6pn3/TMLwVgnCGjnXlw6dChTxLzO60RQ==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "3.928.0",
-        "@aws-sdk/types": "3.922.0",
-        "@smithy/fetch-http-handler": "^5.3.5",
-        "@smithy/node-http-handler": "^4.4.4",
-        "@smithy/property-provider": "^4.2.4",
-        "@smithy/protocol-http": "^5.3.4",
-        "@smithy/smithy-client": "^4.9.2",
-        "@smithy/types": "^4.8.1",
-        "@smithy/util-stream": "^4.5.5",
+        "@aws-sdk/core": "3.934.0",
+        "@aws-sdk/types": "3.930.0",
+        "@smithy/fetch-http-handler": "^5.3.6",
+        "@smithy/node-http-handler": "^4.4.5",
+        "@smithy/property-provider": "^4.2.5",
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/smithy-client": "^4.9.5",
+        "@smithy/types": "^4.9.0",
+        "@smithy/util-stream": "^4.5.6",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -454,22 +463,23 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.929.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.929.0.tgz",
-      "integrity": "sha512-XIzWsJUYeS/DjggHFB53sGGjXdlN/BA6x+Y/JvLbpdkGD2yLISU34/cDPbK/O8BAQCRTCQ69VPa/1AdNgZZRQw==",
+      "version": "3.934.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.934.0.tgz",
+      "integrity": "sha512-3vVKGe1F2S09G9kC0ZcpWh09opyrGOgQETllqWbuxlTVd7zBgrZWloItLIvneSDP+dWvdLFUbkD7WDWNCeGiig==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "3.928.0",
-        "@aws-sdk/credential-provider-env": "3.928.0",
-        "@aws-sdk/credential-provider-http": "3.928.0",
-        "@aws-sdk/credential-provider-process": "3.928.0",
-        "@aws-sdk/credential-provider-sso": "3.929.0",
-        "@aws-sdk/credential-provider-web-identity": "3.929.0",
-        "@aws-sdk/nested-clients": "3.929.0",
-        "@aws-sdk/types": "3.922.0",
-        "@smithy/credential-provider-imds": "^4.2.4",
-        "@smithy/property-provider": "^4.2.4",
-        "@smithy/shared-ini-file-loader": "^4.3.4",
-        "@smithy/types": "^4.8.1",
+        "@aws-sdk/core": "3.934.0",
+        "@aws-sdk/credential-provider-env": "3.934.0",
+        "@aws-sdk/credential-provider-http": "3.934.0",
+        "@aws-sdk/credential-provider-process": "3.934.0",
+        "@aws-sdk/credential-provider-sso": "3.934.0",
+        "@aws-sdk/credential-provider-web-identity": "3.934.0",
+        "@aws-sdk/nested-clients": "3.934.0",
+        "@aws-sdk/types": "3.930.0",
+        "@smithy/credential-provider-imds": "^4.2.5",
+        "@smithy/property-provider": "^4.2.5",
+        "@smithy/shared-ini-file-loader": "^4.4.0",
+        "@smithy/types": "^4.9.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -477,21 +487,22 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.929.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.929.0.tgz",
-      "integrity": "sha512-GhNZEacpa7fh8GNggshm5S93UK25bCV5aDK8c2vfe7Y3OxBiL89Ox5GUKCu0xIOqiBdfYkI9wvWCFsQRRn7Bjw==",
+      "version": "3.934.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.934.0.tgz",
+      "integrity": "sha512-nguy36xi8nbH346dJjCmwWtOgfS4VfL7yHP+EEGmma+yg+J7mxgs8kA1NGQdJ8B46GdjlJPpI1P9pm7Pmz7nOw==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "3.928.0",
-        "@aws-sdk/credential-provider-http": "3.928.0",
-        "@aws-sdk/credential-provider-ini": "3.929.0",
-        "@aws-sdk/credential-provider-process": "3.928.0",
-        "@aws-sdk/credential-provider-sso": "3.929.0",
-        "@aws-sdk/credential-provider-web-identity": "3.929.0",
-        "@aws-sdk/types": "3.922.0",
-        "@smithy/credential-provider-imds": "^4.2.4",
-        "@smithy/property-provider": "^4.2.4",
-        "@smithy/shared-ini-file-loader": "^4.3.4",
-        "@smithy/types": "^4.8.1",
+        "@aws-sdk/credential-provider-env": "3.934.0",
+        "@aws-sdk/credential-provider-http": "3.934.0",
+        "@aws-sdk/credential-provider-ini": "3.934.0",
+        "@aws-sdk/credential-provider-process": "3.934.0",
+        "@aws-sdk/credential-provider-sso": "3.934.0",
+        "@aws-sdk/credential-provider-web-identity": "3.934.0",
+        "@aws-sdk/types": "3.930.0",
+        "@smithy/credential-provider-imds": "^4.2.5",
+        "@smithy/property-provider": "^4.2.5",
+        "@smithy/shared-ini-file-loader": "^4.4.0",
+        "@smithy/types": "^4.9.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -499,15 +510,16 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.928.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.928.0.tgz",
-      "integrity": "sha512-XL0juran8yhqwn0mreV+NJeHJOkcRBaExsvVn9fXWW37A4gLh4esSJxM2KbSNh0t+/Bk3ehBI5sL9xad+yRDuw==",
+      "version": "3.934.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.934.0.tgz",
+      "integrity": "sha512-PhvpAgoJ88IOuqlUws9nvHuPex2jK+WS+0s00BQcRTwqPP0jtLT7eql6UfCRduwv2sIy3m1wnWDUubvbpejp/Q==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "3.928.0",
-        "@aws-sdk/types": "3.922.0",
-        "@smithy/property-provider": "^4.2.4",
-        "@smithy/shared-ini-file-loader": "^4.3.4",
-        "@smithy/types": "^4.8.1",
+        "@aws-sdk/core": "3.934.0",
+        "@aws-sdk/types": "3.930.0",
+        "@smithy/property-provider": "^4.2.5",
+        "@smithy/shared-ini-file-loader": "^4.4.0",
+        "@smithy/types": "^4.9.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -515,17 +527,18 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.929.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.929.0.tgz",
-      "integrity": "sha512-aADe6cLo4+9MUOe0GnC5kUn8IduEKnTxqBlsciZOplU0/0+Rdp9rRh/e9ZBskeIXZ33eO2HG+KDAf1lvtPT7dA==",
+      "version": "3.934.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.934.0.tgz",
+      "integrity": "sha512-7wO86w95V9MZSYo2dunBKruKHdAUmgg9ccOSJSYGnPip1PPBK/rgSgQ8mDlYtFAW3/82bdeM/668QcgLT4+ofA==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/client-sso": "3.929.0",
-        "@aws-sdk/core": "3.928.0",
-        "@aws-sdk/token-providers": "3.929.0",
-        "@aws-sdk/types": "3.922.0",
-        "@smithy/property-provider": "^4.2.4",
-        "@smithy/shared-ini-file-loader": "^4.3.4",
-        "@smithy/types": "^4.8.1",
+        "@aws-sdk/client-sso": "3.934.0",
+        "@aws-sdk/core": "3.934.0",
+        "@aws-sdk/token-providers": "3.934.0",
+        "@aws-sdk/types": "3.930.0",
+        "@smithy/property-provider": "^4.2.5",
+        "@smithy/shared-ini-file-loader": "^4.4.0",
+        "@smithy/types": "^4.9.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -533,16 +546,17 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.929.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.929.0.tgz",
-      "integrity": "sha512-L18JtW28xUZVTRHblgqZ8QTVGQfxpMLIuVYgQXrVWiY9Iz9EF4XrfZo3ywCAgqfgLi5pgg3fCxx/pe7uiMOs2w==",
+      "version": "3.934.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.934.0.tgz",
+      "integrity": "sha512-hb+lvFxiAPcAvUorB0hrUd1kDjDRXhZgCi5426I8KUpGzZ+ALh8/ep0KXAiYe2yg9ZkyMUbMaMvYYhMFcbXRFA==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "3.928.0",
-        "@aws-sdk/nested-clients": "3.929.0",
-        "@aws-sdk/types": "3.922.0",
-        "@smithy/property-provider": "^4.2.4",
-        "@smithy/shared-ini-file-loader": "^4.3.4",
-        "@smithy/types": "^4.8.1",
+        "@aws-sdk/core": "3.934.0",
+        "@aws-sdk/nested-clients": "3.934.0",
+        "@aws-sdk/types": "3.930.0",
+        "@smithy/property-provider": "^4.2.5",
+        "@smithy/shared-ini-file-loader": "^4.4.0",
+        "@smithy/types": "^4.9.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -550,15 +564,16 @@
       }
     },
     "node_modules/@aws-sdk/middleware-bucket-endpoint": {
-      "version": "3.922.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.922.0.tgz",
-      "integrity": "sha512-Dpr2YeOaLFqt3q1hocwBesynE3x8/dXZqXZRuzSX/9/VQcwYBFChHAm4mTAl4zuvArtDbLrwzWSxmOWYZGtq5w==",
+      "version": "3.930.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.930.0.tgz",
+      "integrity": "sha512-cnCLWeKPYgvV4yRYPFH6pWMdUByvu2cy2BAlfsPpvnm4RaVioztyvxmQj5PmVN5fvWs5w/2d6U7le8X9iye2sA==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "3.922.0",
+        "@aws-sdk/types": "3.930.0",
         "@aws-sdk/util-arn-parser": "3.893.0",
-        "@smithy/node-config-provider": "^4.3.4",
-        "@smithy/protocol-http": "^5.3.4",
-        "@smithy/types": "^4.8.1",
+        "@smithy/node-config-provider": "^4.3.5",
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/types": "^4.9.0",
         "@smithy/util-config-provider": "^4.2.0",
         "tslib": "^2.6.2"
       },
@@ -567,13 +582,14 @@
       }
     },
     "node_modules/@aws-sdk/middleware-expect-continue": {
-      "version": "3.922.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.922.0.tgz",
-      "integrity": "sha512-xmnLWMtmHJHJBupSWMUEW1gyxuRIeQ1Ov2xa8Tqq77fPr4Ft2AluEwiDMaZIMHoAvpxWKEEt9Si59Li7GIA+bQ==",
+      "version": "3.930.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.930.0.tgz",
+      "integrity": "sha512-5HEQ+JU4DrLNWeY27wKg/jeVa8Suy62ivJHOSUf6e6hZdVIMx0h/kXS1fHEQNNiLu2IzSEP/bFXsKBaW7x7s0g==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "3.922.0",
-        "@smithy/protocol-http": "^5.3.4",
-        "@smithy/types": "^4.8.1",
+        "@aws-sdk/types": "3.930.0",
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/types": "^4.9.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -581,21 +597,22 @@
       }
     },
     "node_modules/@aws-sdk/middleware-flexible-checksums": {
-      "version": "3.928.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.928.0.tgz",
-      "integrity": "sha512-9+aCRt7teItSIMbnGvOY+FhtJnW2ZBUbfD+ug29a/ZbobDfTwmtrmtgEIWdXryFaRbT03HHfaJ3a++lTw4osuw==",
+      "version": "3.934.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.934.0.tgz",
+      "integrity": "sha512-kAV0fhwUhh/CV8hR5iip+du5QSXvIsONERVY/iJPbiBItqsmFaWcwiZE9E+ORJPNyoT/3X17632W33pCweKGDQ==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/crc32": "5.2.0",
         "@aws-crypto/crc32c": "5.2.0",
         "@aws-crypto/util": "5.2.0",
-        "@aws-sdk/core": "3.928.0",
-        "@aws-sdk/types": "3.922.0",
+        "@aws-sdk/core": "3.934.0",
+        "@aws-sdk/types": "3.930.0",
         "@smithy/is-array-buffer": "^4.2.0",
-        "@smithy/node-config-provider": "^4.3.4",
-        "@smithy/protocol-http": "^5.3.4",
-        "@smithy/types": "^4.8.1",
-        "@smithy/util-middleware": "^4.2.4",
-        "@smithy/util-stream": "^4.5.5",
+        "@smithy/node-config-provider": "^4.3.5",
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/types": "^4.9.0",
+        "@smithy/util-middleware": "^4.2.5",
+        "@smithy/util-stream": "^4.5.6",
         "@smithy/util-utf8": "^4.2.0",
         "tslib": "^2.6.2"
       },
@@ -604,13 +621,14 @@
       }
     },
     "node_modules/@aws-sdk/middleware-host-header": {
-      "version": "3.922.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.922.0.tgz",
-      "integrity": "sha512-HPquFgBnq/KqKRVkiuCt97PmWbKtxQ5iUNLEc6FIviqOoZTmaYG3EDsIbuFBz9C4RHJU4FKLmHL2bL3FEId6AA==",
+      "version": "3.930.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.930.0.tgz",
+      "integrity": "sha512-x30jmm3TLu7b/b+67nMyoV0NlbnCVT5DI57yDrhXAPCtdgM1KtdLWt45UcHpKOm1JsaIkmYRh2WYu7Anx4MG0g==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "3.922.0",
-        "@smithy/protocol-http": "^5.3.4",
-        "@smithy/types": "^4.8.1",
+        "@aws-sdk/types": "3.930.0",
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/types": "^4.9.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -618,12 +636,13 @@
       }
     },
     "node_modules/@aws-sdk/middleware-location-constraint": {
-      "version": "3.922.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.922.0.tgz",
-      "integrity": "sha512-T4iqd7WQ2DDjCH/0s50mnhdoX+IJns83ZE+3zj9IDlpU0N2aq8R91IG890qTfYkUEdP9yRm0xir/CNed+v6Dew==",
+      "version": "3.930.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.930.0.tgz",
+      "integrity": "sha512-QIGNsNUdRICog+LYqmtJ03PLze6h2KCORXUs5td/hAEjVP5DMmubhtrGg1KhWyctACluUH/E/yrD14p4pRXxwA==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "3.922.0",
-        "@smithy/types": "^4.8.1",
+        "@aws-sdk/types": "3.930.0",
+        "@smithy/types": "^4.9.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -631,12 +650,13 @@
       }
     },
     "node_modules/@aws-sdk/middleware-logger": {
-      "version": "3.922.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.922.0.tgz",
-      "integrity": "sha512-AkvYO6b80FBm5/kk2E636zNNcNgjztNNUxpqVx+huyGn9ZqGTzS4kLqW2hO6CBe5APzVtPCtiQsXL24nzuOlAg==",
+      "version": "3.930.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.930.0.tgz",
+      "integrity": "sha512-vh4JBWzMCBW8wREvAwoSqB2geKsZwSHTa0nSt0OMOLp2PdTYIZDi0ZiVMmpfnjcx9XbS6aSluLv9sKx4RrG46A==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "3.922.0",
-        "@smithy/types": "^4.8.1",
+        "@aws-sdk/types": "3.930.0",
+        "@smithy/types": "^4.9.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -644,14 +664,15 @@
       }
     },
     "node_modules/@aws-sdk/middleware-recursion-detection": {
-      "version": "3.922.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.922.0.tgz",
-      "integrity": "sha512-TtSCEDonV/9R0VhVlCpxZbp/9sxQvTTRKzIf8LxW3uXpby6Wl8IxEciBJlxmSkoqxh542WRcko7NYODlvL/gDA==",
+      "version": "3.933.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.933.0.tgz",
+      "integrity": "sha512-qgrMlkVKzTCAdNw2A05DC2sPBo0KRQ7wk+lbYSRJnWVzcrceJhnmhoZVV5PFv7JtchK7sHVcfm9lcpiyd+XaCA==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "3.922.0",
-        "@aws/lambda-invoke-store": "^0.1.1",
-        "@smithy/protocol-http": "^5.3.4",
-        "@smithy/types": "^4.8.1",
+        "@aws-sdk/types": "3.930.0",
+        "@aws/lambda-invoke-store": "^0.2.0",
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/types": "^4.9.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -659,22 +680,23 @@
       }
     },
     "node_modules/@aws-sdk/middleware-sdk-s3": {
-      "version": "3.928.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.928.0.tgz",
-      "integrity": "sha512-LTkjS6cpJ2PEtsottTKq7JxZV0oH+QJ12P/dGNPZL4URayjEMBVR/dp4zh835X/FPXzijga3sdotlIKzuFy9FA==",
+      "version": "3.934.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.934.0.tgz",
+      "integrity": "sha512-eU2R7pVOhCxnkDzq9mW+xh4WvCA3mdXVUHezIcJNFyKCKKv/c9I4WFcnMnUy+wnCWO2mzN/gwSgQxADkvxfLNQ==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "3.928.0",
-        "@aws-sdk/types": "3.922.0",
+        "@aws-sdk/core": "3.934.0",
+        "@aws-sdk/types": "3.930.0",
         "@aws-sdk/util-arn-parser": "3.893.0",
-        "@smithy/core": "^3.17.2",
-        "@smithy/node-config-provider": "^4.3.4",
-        "@smithy/protocol-http": "^5.3.4",
-        "@smithy/signature-v4": "^5.3.4",
-        "@smithy/smithy-client": "^4.9.2",
-        "@smithy/types": "^4.8.1",
+        "@smithy/core": "^3.18.2",
+        "@smithy/node-config-provider": "^4.3.5",
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/signature-v4": "^5.3.5",
+        "@smithy/smithy-client": "^4.9.5",
+        "@smithy/types": "^4.9.0",
         "@smithy/util-config-provider": "^4.2.0",
-        "@smithy/util-middleware": "^4.2.4",
-        "@smithy/util-stream": "^4.5.5",
+        "@smithy/util-middleware": "^4.2.5",
+        "@smithy/util-stream": "^4.5.6",
         "@smithy/util-utf8": "^4.2.0",
         "tslib": "^2.6.2"
       },
@@ -683,12 +705,13 @@
       }
     },
     "node_modules/@aws-sdk/middleware-ssec": {
-      "version": "3.922.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-3.922.0.tgz",
-      "integrity": "sha512-eHvSJZTSRJO+/tjjGD6ocnPc8q9o3m26+qbwQTu/4V6yOJQ1q+xkDZNqwJQphL+CodYaQ7uljp8g1Ji/AN3D9w==",
+      "version": "3.930.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-3.930.0.tgz",
+      "integrity": "sha512-N2/SvodmaDS6h7CWfuapt3oJyn1T2CBz0CsDIiTDv9cSagXAVFjPdm2g4PFJqrNBeqdDIoYBnnta336HmamWHg==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "3.922.0",
-        "@smithy/types": "^4.8.1",
+        "@aws-sdk/types": "3.930.0",
+        "@smithy/types": "^4.9.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -696,16 +719,17 @@
       }
     },
     "node_modules/@aws-sdk/middleware-user-agent": {
-      "version": "3.928.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.928.0.tgz",
-      "integrity": "sha512-ESvcfLx5PtpdUM3ptCwb80toBTd3y5I4w5jaeOPHihiZr7jkRLE/nsaCKzlqscPs6UQ8xI0maav04JUiTskcHw==",
+      "version": "3.934.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.934.0.tgz",
+      "integrity": "sha512-68giGM2Zm9K6Qas14ws3Qo5wafpn0I8/L64fS9E6Rc6Tu0k+So73hupysw+9ZOzHwQS5FEBUqLOMtbUibAcjNA==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "3.928.0",
-        "@aws-sdk/types": "3.922.0",
-        "@aws-sdk/util-endpoints": "3.922.0",
-        "@smithy/core": "^3.17.2",
-        "@smithy/protocol-http": "^5.3.4",
-        "@smithy/types": "^4.8.1",
+        "@aws-sdk/core": "3.934.0",
+        "@aws-sdk/types": "3.930.0",
+        "@aws-sdk/util-endpoints": "3.930.0",
+        "@smithy/core": "^3.18.2",
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/types": "^4.9.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -713,46 +737,47 @@
       }
     },
     "node_modules/@aws-sdk/nested-clients": {
-      "version": "3.929.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.929.0.tgz",
-      "integrity": "sha512-emR4LTSupxPed1ni0zVxz5msezz/gA1YYXooiW567+NyhvLgSzDvNjK7GPU1waLCj1LrRFe7NkXX1pwa5sPrpw==",
+      "version": "3.934.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.934.0.tgz",
+      "integrity": "sha512-kRO61EMrDR4UuPlKAkziG6urcYXlhrFW/Ce5PjWFdjkm0ZOge75OFV1vhf/vE4Pmoop9jaAONX4E5BaIYrIQfg==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "3.928.0",
-        "@aws-sdk/middleware-host-header": "3.922.0",
-        "@aws-sdk/middleware-logger": "3.922.0",
-        "@aws-sdk/middleware-recursion-detection": "3.922.0",
-        "@aws-sdk/middleware-user-agent": "3.928.0",
-        "@aws-sdk/region-config-resolver": "3.925.0",
-        "@aws-sdk/types": "3.922.0",
-        "@aws-sdk/util-endpoints": "3.922.0",
-        "@aws-sdk/util-user-agent-browser": "3.922.0",
-        "@aws-sdk/util-user-agent-node": "3.928.0",
-        "@smithy/config-resolver": "^4.4.2",
-        "@smithy/core": "^3.17.2",
-        "@smithy/fetch-http-handler": "^5.3.5",
-        "@smithy/hash-node": "^4.2.4",
-        "@smithy/invalid-dependency": "^4.2.4",
-        "@smithy/middleware-content-length": "^4.2.4",
-        "@smithy/middleware-endpoint": "^4.3.6",
-        "@smithy/middleware-retry": "^4.4.6",
-        "@smithy/middleware-serde": "^4.2.4",
-        "@smithy/middleware-stack": "^4.2.4",
-        "@smithy/node-config-provider": "^4.3.4",
-        "@smithy/node-http-handler": "^4.4.4",
-        "@smithy/protocol-http": "^5.3.4",
-        "@smithy/smithy-client": "^4.9.2",
-        "@smithy/types": "^4.8.1",
-        "@smithy/url-parser": "^4.2.4",
+        "@aws-sdk/core": "3.934.0",
+        "@aws-sdk/middleware-host-header": "3.930.0",
+        "@aws-sdk/middleware-logger": "3.930.0",
+        "@aws-sdk/middleware-recursion-detection": "3.933.0",
+        "@aws-sdk/middleware-user-agent": "3.934.0",
+        "@aws-sdk/region-config-resolver": "3.930.0",
+        "@aws-sdk/types": "3.930.0",
+        "@aws-sdk/util-endpoints": "3.930.0",
+        "@aws-sdk/util-user-agent-browser": "3.930.0",
+        "@aws-sdk/util-user-agent-node": "3.934.0",
+        "@smithy/config-resolver": "^4.4.3",
+        "@smithy/core": "^3.18.2",
+        "@smithy/fetch-http-handler": "^5.3.6",
+        "@smithy/hash-node": "^4.2.5",
+        "@smithy/invalid-dependency": "^4.2.5",
+        "@smithy/middleware-content-length": "^4.2.5",
+        "@smithy/middleware-endpoint": "^4.3.9",
+        "@smithy/middleware-retry": "^4.4.9",
+        "@smithy/middleware-serde": "^4.2.5",
+        "@smithy/middleware-stack": "^4.2.5",
+        "@smithy/node-config-provider": "^4.3.5",
+        "@smithy/node-http-handler": "^4.4.5",
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/smithy-client": "^4.9.5",
+        "@smithy/types": "^4.9.0",
+        "@smithy/url-parser": "^4.2.5",
         "@smithy/util-base64": "^4.3.0",
         "@smithy/util-body-length-browser": "^4.2.0",
         "@smithy/util-body-length-node": "^4.2.1",
-        "@smithy/util-defaults-mode-browser": "^4.3.5",
-        "@smithy/util-defaults-mode-node": "^4.2.8",
-        "@smithy/util-endpoints": "^3.2.4",
-        "@smithy/util-middleware": "^4.2.4",
-        "@smithy/util-retry": "^4.2.4",
+        "@smithy/util-defaults-mode-browser": "^4.3.8",
+        "@smithy/util-defaults-mode-node": "^4.2.11",
+        "@smithy/util-endpoints": "^3.2.5",
+        "@smithy/util-middleware": "^4.2.5",
+        "@smithy/util-retry": "^4.2.5",
         "@smithy/util-utf8": "^4.2.0",
         "tslib": "^2.6.2"
       },
@@ -761,14 +786,15 @@
       }
     },
     "node_modules/@aws-sdk/region-config-resolver": {
-      "version": "3.925.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.925.0.tgz",
-      "integrity": "sha512-FOthcdF9oDb1pfQBRCfWPZhJZT5wqpvdAS5aJzB1WDZ+6EuaAhLzLH/fW1slDunIqq1PSQGG3uSnVglVVOvPHQ==",
+      "version": "3.930.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.930.0.tgz",
+      "integrity": "sha512-KL2JZqH6aYeQssu1g1KuWsReupdfOoxD6f1as2VC+rdwYFUu4LfzMsFfXnBvvQWWqQ7rZHWOw1T+o5gJmg7Dzw==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "3.922.0",
-        "@smithy/config-resolver": "^4.4.2",
-        "@smithy/node-config-provider": "^4.3.4",
-        "@smithy/types": "^4.8.1",
+        "@aws-sdk/types": "3.930.0",
+        "@smithy/config-resolver": "^4.4.3",
+        "@smithy/node-config-provider": "^4.3.5",
+        "@smithy/types": "^4.9.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -776,15 +802,16 @@
       }
     },
     "node_modules/@aws-sdk/signature-v4-multi-region": {
-      "version": "3.928.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.928.0.tgz",
-      "integrity": "sha512-1+Ic8+MyqQy+OE6QDoQKVCIcSZO+ETmLLLpVS5yu0fihBU85B5HHU7iaKX1qX7lEaGPMpSN/mbHW0VpyQ0Xqaw==",
+      "version": "3.934.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.934.0.tgz",
+      "integrity": "sha512-cLphxVoHapSdouAdLSDEwR2Bktjg5dc11EpSpaLo8jcFpAXhFaDllKBfDfws0EqGY6N2CMqEjqPqxDFzmmQOQA==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/middleware-sdk-s3": "3.928.0",
-        "@aws-sdk/types": "3.922.0",
-        "@smithy/protocol-http": "^5.3.4",
-        "@smithy/signature-v4": "^5.3.4",
-        "@smithy/types": "^4.8.1",
+        "@aws-sdk/middleware-sdk-s3": "3.934.0",
+        "@aws-sdk/types": "3.930.0",
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/signature-v4": "^5.3.5",
+        "@smithy/types": "^4.9.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -792,16 +819,17 @@
       }
     },
     "node_modules/@aws-sdk/token-providers": {
-      "version": "3.929.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.929.0.tgz",
-      "integrity": "sha512-78kph1R6TVJ53VXDKUmt64HMqWjTECLymJ7kLguz2QJiWh2ZdLvpyYGvaueEwwhisHYBh2qef1tGIf/PpEb8SQ==",
+      "version": "3.934.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.934.0.tgz",
+      "integrity": "sha512-M0WEmgXDdUxapSfjplqJoVCBMcn0vQ5Jou0X/XiQwyVDbfvIyNSHUHyMXEIBAew9kVx9sfMMEYz3LXewvQxdCA==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "3.928.0",
-        "@aws-sdk/nested-clients": "3.929.0",
-        "@aws-sdk/types": "3.922.0",
-        "@smithy/property-provider": "^4.2.4",
-        "@smithy/shared-ini-file-loader": "^4.3.4",
-        "@smithy/types": "^4.8.1",
+        "@aws-sdk/core": "3.934.0",
+        "@aws-sdk/nested-clients": "3.934.0",
+        "@aws-sdk/types": "3.930.0",
+        "@smithy/property-provider": "^4.2.5",
+        "@smithy/shared-ini-file-loader": "^4.4.0",
+        "@smithy/types": "^4.9.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -809,11 +837,12 @@
       }
     },
     "node_modules/@aws-sdk/types": {
-      "version": "3.922.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.922.0.tgz",
-      "integrity": "sha512-eLA6XjVobAUAMivvM7DBL79mnHyrm+32TkXNWZua5mnxF+6kQCfblKKJvxMZLGosO53/Ex46ogim8IY5Nbqv2w==",
+      "version": "3.930.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.930.0.tgz",
+      "integrity": "sha512-we/vaAgwlEFW7IeftmCLlLMw+6hFs3DzZPJw7lVHbj/5HJ0bz9gndxEsS2lQoeJ1zhiiLqAqvXxmM43s0MBg0A==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.8.1",
+        "@smithy/types": "^4.9.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -824,6 +853,7 @@
       "version": "3.893.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-arn-parser/-/util-arn-parser-3.893.0.tgz",
       "integrity": "sha512-u8H4f2Zsi19DGnwj5FSZzDMhytYF/bCh37vAtBsn3cNDL3YG578X5oc+wSX54pM3tOxS+NY7tvOAo52SW7koUA==",
+      "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
       },
@@ -832,14 +862,15 @@
       }
     },
     "node_modules/@aws-sdk/util-endpoints": {
-      "version": "3.922.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.922.0.tgz",
-      "integrity": "sha512-4ZdQCSuNMY8HMlR1YN4MRDdXuKd+uQTeKIr5/pIM+g3TjInZoj8imvXudjcrFGA63UF3t92YVTkBq88mg58RXQ==",
+      "version": "3.930.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.930.0.tgz",
+      "integrity": "sha512-M2oEKBzzNAYr136RRc6uqw3aWlwCxqTP1Lawps9E1d2abRPvl1p1ztQmmXp1Ak4rv8eByIZ+yQyKQ3zPdRG5dw==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "3.922.0",
-        "@smithy/types": "^4.8.1",
-        "@smithy/url-parser": "^4.2.4",
-        "@smithy/util-endpoints": "^3.2.4",
+        "@aws-sdk/types": "3.930.0",
+        "@smithy/types": "^4.9.0",
+        "@smithy/url-parser": "^4.2.5",
+        "@smithy/util-endpoints": "^3.2.5",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -858,25 +889,27 @@
       }
     },
     "node_modules/@aws-sdk/util-user-agent-browser": {
-      "version": "3.922.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.922.0.tgz",
-      "integrity": "sha512-qOJAERZ3Plj1st7M4Q5henl5FRpE30uLm6L9edZqZXGR6c7ry9jzexWamWVpQ4H4xVAVmiO9dIEBAfbq4mduOA==",
+      "version": "3.930.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.930.0.tgz",
+      "integrity": "sha512-q6lCRm6UAe+e1LguM5E4EqM9brQlDem4XDcQ87NzEvlTW6GzmNCO0w1jS0XgCFXQHjDxjdlNFX+5sRbHijwklg==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "3.922.0",
-        "@smithy/types": "^4.8.1",
+        "@aws-sdk/types": "3.930.0",
+        "@smithy/types": "^4.9.0",
         "bowser": "^2.11.0",
         "tslib": "^2.6.2"
       }
     },
     "node_modules/@aws-sdk/util-user-agent-node": {
-      "version": "3.928.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.928.0.tgz",
-      "integrity": "sha512-s0jP67nQLLWVWfBtqTkZUkSWK5e6OI+rs+wFya2h9VLyWBFir17XSDI891s8HZKIVCEl8eBrup+hhywm4nsIAA==",
+      "version": "3.934.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.934.0.tgz",
+      "integrity": "sha512-vPRR4PaqNmuOQJSzq4EAVwFHUaSpPtgDgCEc7AYbArIy+59fckb6JNddlrjx4w4iWbqO0d+7OC5PtRcIk0AcZA==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/middleware-user-agent": "3.928.0",
-        "@aws-sdk/types": "3.922.0",
-        "@smithy/node-config-provider": "^4.3.4",
-        "@smithy/types": "^4.8.1",
+        "@aws-sdk/middleware-user-agent": "3.934.0",
+        "@aws-sdk/types": "3.930.0",
+        "@smithy/node-config-provider": "^4.3.5",
+        "@smithy/types": "^4.9.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -892,11 +925,12 @@
       }
     },
     "node_modules/@aws-sdk/xml-builder": {
-      "version": "3.921.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.921.0.tgz",
-      "integrity": "sha512-LVHg0jgjyicKKvpNIEMXIMr1EBViESxcPkqfOlT+X1FkmUMTNZEEVF18tOJg4m4hV5vxtkWcqtr4IEeWa1C41Q==",
+      "version": "3.930.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.930.0.tgz",
+      "integrity": "sha512-YIfkD17GocxdmlUVc3ia52QhcWuRIUJonbF8A2CYfcWNV3HzvAqpcPeC0bYUhkK+8e8YO1ARnLKZQE0TlwzorA==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.8.1",
+        "@smithy/types": "^4.9.0",
         "fast-xml-parser": "5.2.5",
         "tslib": "^2.6.2"
       },
@@ -905,9 +939,10 @@
       }
     },
     "node_modules/@aws/lambda-invoke-store": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.1.1.tgz",
-      "integrity": "sha512-RcLam17LdlbSOSp9VxmUu1eI6Mwxp+OwhD2QhiSNmNCzoDb0EeUXTD2n/WbcnrAYMGlmf05th6QYq23VqvJqpA==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.2.0.tgz",
+      "integrity": "sha512-D1jAmAZQYMoPiacfgNf7AWhg3DFN3Wq/vQv3WINt9znwjzHp2x+WzdJFxxj7xZL7V1U79As6G8f7PorMYWBKsQ==",
+      "license": "Apache-2.0",
       "engines": {
         "node": ">=18.0.0"
       }
@@ -943,7 +978,6 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -1422,7 +1456,6 @@
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
       "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
-      "peer": true,
       "dependencies": {
         "@dnd-kit/accessibility": "^3.1.1",
         "@dnd-kit/utilities": "^3.2.2",
@@ -1627,7 +1660,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -2371,7 +2403,6 @@
       "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^14.21.3 || >=16"
       },
@@ -3278,6 +3309,7 @@
       "version": "1.3.6",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-slider/-/react-slider-1.3.6.tgz",
       "integrity": "sha512-JPYb1GuM1bxfjMRlNLE+BcmBC8onfCi60Blk7OBqi2MLTFdS+8401U4uFjnwkOr49BLmXxLC6JHkvAsx5OJvHw==",
+      "license": "MIT",
       "dependencies": {
         "@radix-ui/number": "1.1.1",
         "@radix-ui/primitive": "1.1.3",
@@ -3740,6 +3772,7 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.4.3.tgz",
       "integrity": "sha512-ezHLe1tKLUxDJo2LHtDuEDyWXolw8WGOR92qb4bQdWq/zKenO5BvctZGrVJBK08zjezSk7bmbKFOXIVyChvDLw==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@smithy/node-config-provider": "^4.3.5",
         "@smithy/types": "^4.9.0",
@@ -3753,11 +3786,12 @@
       }
     },
     "node_modules/@smithy/core": {
-      "version": "3.18.0",
-      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.18.0.tgz",
-      "integrity": "sha512-vGSDXOJFZgOPTatSI1ly7Gwyy/d/R9zh2TO3y0JZ0uut5qQ88p9IaWaZYIWSSqtdekNM4CGok/JppxbAff4KcQ==",
+      "version": "3.18.5",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.18.5.tgz",
+      "integrity": "sha512-6gnIz3h+PEPQGDj8MnRSjDvKBah042jEoPgjFGJ4iJLBE78L4lY/n98x14XyPF4u3lN179Ub/ZKFY5za9GeLQw==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/middleware-serde": "^4.2.5",
+        "@smithy/middleware-serde": "^4.2.6",
         "@smithy/protocol-http": "^5.3.5",
         "@smithy/types": "^4.9.0",
         "@smithy/util-base64": "^4.3.0",
@@ -3776,6 +3810,7 @@
       "version": "4.2.5",
       "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.2.5.tgz",
       "integrity": "sha512-BZwotjoZWn9+36nimwm/OLIcVe+KYRwzMjfhd4QT7QxPm9WY0HiOV8t/Wlh+HVUif0SBVV7ksq8//hPaBC/okQ==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@smithy/node-config-provider": "^4.3.5",
         "@smithy/property-provider": "^4.2.5",
@@ -3856,6 +3891,7 @@
       "version": "5.3.6",
       "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.3.6.tgz",
       "integrity": "sha512-3+RG3EA6BBJ/ofZUeTFJA7mHfSYrZtQIrDP9dI8Lf7X6Jbos2jptuLrAAteDiFVrmbEmLSuRG/bUKzfAXk7dhg==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@smithy/protocol-http": "^5.3.5",
         "@smithy/querystring-builder": "^4.2.5",
@@ -3885,6 +3921,7 @@
       "version": "4.2.5",
       "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-4.2.5.tgz",
       "integrity": "sha512-DpYX914YOfA3UDT9CN1BM787PcHfWRBB43fFGCYrZFUH0Jv+5t8yYl+Pd5PW4+QzoGEDvn5d5QIO4j2HyYZQSA==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.9.0",
         "@smithy/util-buffer-from": "^4.2.0",
@@ -3912,6 +3949,7 @@
       "version": "4.2.5",
       "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-4.2.5.tgz",
       "integrity": "sha512-2L2erASEro1WC5nV+plwIMxrTXpvpfzl4e+Nre6vBVRR2HKeGGcvpJyyL3/PpiSg+cJG2KpTmZmq934Olb6e5A==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.9.0",
         "tslib": "^2.6.2"
@@ -3948,6 +3986,7 @@
       "version": "4.2.5",
       "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-4.2.5.tgz",
       "integrity": "sha512-Y/RabVa5vbl5FuHYV2vUCwvh/dqzrEY/K2yWPSqvhFUwIY0atLqO4TienjBXakoy4zrKAMCZwg+YEqmH7jaN7A==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@smithy/protocol-http": "^5.3.5",
         "@smithy/types": "^4.9.0",
@@ -3958,12 +3997,13 @@
       }
     },
     "node_modules/@smithy/middleware-endpoint": {
-      "version": "4.3.7",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.3.7.tgz",
-      "integrity": "sha512-i8Mi8OuY6Yi82Foe3iu7/yhBj1HBRoOQwBSsUNYglJTNSFaWYTNM2NauBBs/7pq2sqkLRqeUXA3Ogi2utzpUlQ==",
+      "version": "4.3.12",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.3.12.tgz",
+      "integrity": "sha512-9pAX/H+VQPzNbouhDhkW723igBMLgrI8OtX+++M7iKJgg/zY/Ig3i1e6seCcx22FWhE6Q/S61BRdi2wXBORT+A==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.18.0",
-        "@smithy/middleware-serde": "^4.2.5",
+        "@smithy/core": "^3.18.5",
+        "@smithy/middleware-serde": "^4.2.6",
         "@smithy/node-config-provider": "^4.3.5",
         "@smithy/shared-ini-file-loader": "^4.4.0",
         "@smithy/types": "^4.9.0",
@@ -3976,14 +4016,15 @@
       }
     },
     "node_modules/@smithy/middleware-retry": {
-      "version": "4.4.7",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.4.7.tgz",
-      "integrity": "sha512-E7Vc6WHCHlzDRTx1W0jZ6J1L6ziEV0PIWcUdmfL4y+c8r7WYr6I+LkQudaD8Nfb7C5c4P3SQ972OmXHtv6m/OA==",
+      "version": "4.4.12",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.4.12.tgz",
+      "integrity": "sha512-S4kWNKFowYd0lID7/DBqWHOQxmxlsf0jBaos9chQZUWTVOjSW1Ogyh8/ib5tM+agFDJ/TCxuCTvrnlc+9cIBcQ==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@smithy/node-config-provider": "^4.3.5",
         "@smithy/protocol-http": "^5.3.5",
         "@smithy/service-error-classification": "^4.2.5",
-        "@smithy/smithy-client": "^4.9.3",
+        "@smithy/smithy-client": "^4.9.8",
         "@smithy/types": "^4.9.0",
         "@smithy/util-middleware": "^4.2.5",
         "@smithy/util-retry": "^4.2.5",
@@ -3995,9 +4036,10 @@
       }
     },
     "node_modules/@smithy/middleware-serde": {
-      "version": "4.2.5",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.2.5.tgz",
-      "integrity": "sha512-La1ldWTJTZ5NqQyPqnCNeH9B+zjFhrNoQIL1jTh4zuqXRlmXhxYHhMtI1/92OlnoAtp6JoN7kzuwhWoXrBwPqg==",
+      "version": "4.2.6",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.2.6.tgz",
+      "integrity": "sha512-VkLoE/z7e2g8pirwisLz8XJWedUSY8my/qrp81VmAdyrhi94T+riBfwP+AOEEFR9rFTSonC/5D2eWNmFabHyGQ==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@smithy/protocol-http": "^5.3.5",
         "@smithy/types": "^4.9.0",
@@ -4011,6 +4053,7 @@
       "version": "4.2.5",
       "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.2.5.tgz",
       "integrity": "sha512-bYrutc+neOyWxtZdbB2USbQttZN0mXaOyYLIsaTbJhFsfpXyGWUxJpEuO1rJ8IIJm2qH4+xJT0mxUSsEDTYwdQ==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.9.0",
         "tslib": "^2.6.2"
@@ -4023,6 +4066,7 @@
       "version": "4.3.5",
       "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.3.5.tgz",
       "integrity": "sha512-UTurh1C4qkVCtqggI36DGbLB2Kv8UlcFdMXDcWMbqVY2uRg0XmT9Pb4Vj6oSQ34eizO1fvR0RnFV4Axw4IrrAg==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@smithy/property-provider": "^4.2.5",
         "@smithy/shared-ini-file-loader": "^4.4.0",
@@ -4037,6 +4081,7 @@
       "version": "4.4.5",
       "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.4.5.tgz",
       "integrity": "sha512-CMnzM9R2WqlqXQGtIlsHMEZfXKJVTIrqCNoSd/QpAyp+Dw0a1Vps13l6ma1fH8g7zSPNsA59B/kWgeylFuA/lw==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@smithy/abort-controller": "^4.2.5",
         "@smithy/protocol-http": "^5.3.5",
@@ -4052,6 +4097,7 @@
       "version": "4.2.5",
       "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.2.5.tgz",
       "integrity": "sha512-8iLN1XSE1rl4MuxvQ+5OSk/Zb5El7NJZ1td6Tn+8dQQHIjp59Lwl6bd0+nzw6SKm2wSSriH2v/I9LPzUic7EOg==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.9.0",
         "tslib": "^2.6.2"
@@ -4064,6 +4110,7 @@
       "version": "5.3.5",
       "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.5.tgz",
       "integrity": "sha512-RlaL+sA0LNMp03bf7XPbFmT5gN+w3besXSWMkA8rcmxLSVfiEXElQi4O2IWwPfxzcHkxqrwBFMbngB8yx/RvaQ==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.9.0",
         "tslib": "^2.6.2"
@@ -4076,6 +4123,7 @@
       "version": "4.2.5",
       "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.2.5.tgz",
       "integrity": "sha512-y98otMI1saoajeik2kLfGyRp11e5U/iJYH/wLCh3aTV/XutbGT9nziKGkgCaMD1ghK7p6htHMm6b6scl9JRUWg==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.9.0",
         "@smithy/util-uri-escape": "^4.2.0",
@@ -4089,6 +4137,7 @@
       "version": "4.2.5",
       "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.2.5.tgz",
       "integrity": "sha512-031WCTdPYgiQRYNPXznHXof2YM0GwL6SeaSyTH/P72M1Vz73TvCNH2Nq8Iu2IEPq9QP2yx0/nrw5YmSeAi/AjQ==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.9.0",
         "tslib": "^2.6.2"
@@ -4101,6 +4150,7 @@
       "version": "4.2.5",
       "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.2.5.tgz",
       "integrity": "sha512-8fEvK+WPE3wUAcDvqDQG1Vk3ANLR8Px979te96m84CbKAjBVf25rPYSzb4xU4hlTyho7VhOGnh5i62D/JVF0JQ==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.9.0"
       },
@@ -4112,6 +4162,7 @@
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.4.0.tgz",
       "integrity": "sha512-5WmZ5+kJgJDjwXXIzr1vDTG+RhF9wzSODQBfkrQ2VVkYALKGvZX1lgVSxEkgicSAFnFhPj5rudJV0zoinqS0bA==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.9.0",
         "tslib": "^2.6.2"
@@ -4124,6 +4175,7 @@
       "version": "5.3.5",
       "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.3.5.tgz",
       "integrity": "sha512-xSUfMu1FT7ccfSXkoLl/QRQBi2rOvi3tiBZU2Tdy3I6cgvZ6SEi9QNey+lqps/sJRnogIS+lq+B1gxxbra2a/w==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@smithy/is-array-buffer": "^4.2.0",
         "@smithy/protocol-http": "^5.3.5",
@@ -4139,12 +4191,13 @@
       }
     },
     "node_modules/@smithy/smithy-client": {
-      "version": "4.9.3",
-      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.9.3.tgz",
-      "integrity": "sha512-8tlueuTgV5n7inQCkhyptrB3jo2AO80uGrps/XTYZivv5MFQKKBj3CIWIGMI2fRY5LEduIiazOhAWdFknY1O9w==",
+      "version": "4.9.8",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.9.8.tgz",
+      "integrity": "sha512-8xgq3LgKDEFoIrLWBho/oYKyWByw9/corz7vuh1upv7ZBm0ZMjGYBhbn6v643WoIqA9UTcx5A5htEp/YatUwMA==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.18.0",
-        "@smithy/middleware-endpoint": "^4.3.7",
+        "@smithy/core": "^3.18.5",
+        "@smithy/middleware-endpoint": "^4.3.12",
         "@smithy/middleware-stack": "^4.2.5",
         "@smithy/protocol-http": "^5.3.5",
         "@smithy/types": "^4.9.0",
@@ -4170,6 +4223,7 @@
       "version": "4.2.5",
       "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.2.5.tgz",
       "integrity": "sha512-VaxMGsilqFnK1CeBX+LXnSuaMx4sTL/6znSZh2829txWieazdVxr54HmiyTsIbpOTLcf5nYpq9lpzmwRdxj6rQ==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@smithy/querystring-parser": "^4.2.5",
         "@smithy/types": "^4.9.0",
@@ -4196,6 +4250,7 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-4.2.0.tgz",
       "integrity": "sha512-Fkoh/I76szMKJnBXWPdFkQJl2r9SjPt3cMzLdOB6eJ4Pnpas8hVoWPYemX/peO0yrrvldgCUVJqOAjUrOLjbxg==",
+      "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
       },
@@ -4207,6 +4262,7 @@
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-4.2.1.tgz",
       "integrity": "sha512-h53dz/pISVrVrfxV1iqXlx5pRg3V2YWFcSQyPyXZRrZoZj4R4DeWRDo1a7dd3CPTcFi3kE+98tuNyD2axyZReA==",
+      "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
       },
@@ -4230,6 +4286,7 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-4.2.0.tgz",
       "integrity": "sha512-YEjpl6XJ36FTKmD+kRJJWYvrHeUvm5ykaUS5xK+6oXffQPHeEM4/nXlZPe+Wu0lsgRUcNZiliYNh/y7q9c2y6Q==",
+      "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
       },
@@ -4238,12 +4295,13 @@
       }
     },
     "node_modules/@smithy/util-defaults-mode-browser": {
-      "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.3.6.tgz",
-      "integrity": "sha512-kbpuXbEf2YQ9zEE6eeVnUCQWO0e1BjMnKrXL8rfXgiWA0m8/E0leU4oSNzxP04WfCmW8vjEqaDeXWxwE4tpOjQ==",
+      "version": "4.3.11",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.3.11.tgz",
+      "integrity": "sha512-yHv+r6wSQXEXTPVCIQTNmXVWs7ekBTpMVErjqZoWkYN75HIFN5y9+/+sYOejfAuvxWGvgzgxbTHa/oz61YTbKw==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@smithy/property-provider": "^4.2.5",
-        "@smithy/smithy-client": "^4.9.3",
+        "@smithy/smithy-client": "^4.9.8",
         "@smithy/types": "^4.9.0",
         "tslib": "^2.6.2"
       },
@@ -4252,15 +4310,16 @@
       }
     },
     "node_modules/@smithy/util-defaults-mode-node": {
-      "version": "4.2.9",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.2.9.tgz",
-      "integrity": "sha512-dgyribrVWN5qE5usYJ0m5M93mVM3L3TyBPZWe1Xl6uZlH2gzfQx3dz+ZCdW93lWqdedJRkOecnvbnoEEXRZ5VQ==",
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.2.14.tgz",
+      "integrity": "sha512-ljZN3iRvaJUgulfvobIuG97q1iUuCMrvXAlkZ4msY+ZuVHQHDIqn7FKZCEj+bx8omz6kF5yQXms/xhzjIO5XiA==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@smithy/config-resolver": "^4.4.3",
         "@smithy/credential-provider-imds": "^4.2.5",
         "@smithy/node-config-provider": "^4.3.5",
         "@smithy/property-provider": "^4.2.5",
-        "@smithy/smithy-client": "^4.9.3",
+        "@smithy/smithy-client": "^4.9.8",
         "@smithy/types": "^4.9.0",
         "tslib": "^2.6.2"
       },
@@ -4272,6 +4331,7 @@
       "version": "3.2.5",
       "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.2.5.tgz",
       "integrity": "sha512-3O63AAWu2cSNQZp+ayl9I3NapW1p1rR5mlVHcF6hAB1dPZUQFfRPYtplWX/3xrzWthPGj5FqB12taJJCfH6s8A==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@smithy/node-config-provider": "^4.3.5",
         "@smithy/types": "^4.9.0",
@@ -4296,6 +4356,7 @@
       "version": "4.2.5",
       "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.2.5.tgz",
       "integrity": "sha512-6Y3+rvBF7+PZOc40ybeZMcGln6xJGVeY60E7jy9Mv5iKpMJpHgRE6dKy9ScsVxvfAYuEX4Q9a65DQX90KaQ3bA==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.9.0",
         "tslib": "^2.6.2"
@@ -4308,6 +4369,7 @@
       "version": "4.2.5",
       "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.2.5.tgz",
       "integrity": "sha512-GBj3+EZBbN4NAqJ/7pAhsXdfzdlznOh8PydUijy6FpNIMnHPSMO2/rP4HKu+UFeikJxShERk528oy7GT79YiJg==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@smithy/service-error-classification": "^4.2.5",
         "@smithy/types": "^4.9.0",
@@ -4321,6 +4383,7 @@
       "version": "4.5.6",
       "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.5.6.tgz",
       "integrity": "sha512-qWw/UM59TiaFrPevefOZ8CNBKbYEP6wBAIlLqxn3VAIo9rgnTNc4ASbVrqDmhuwI87usnjhdQrxodzAGFFzbRQ==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@smithy/fetch-http-handler": "^5.3.6",
         "@smithy/node-http-handler": "^4.4.5",
@@ -4339,6 +4402,7 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-4.2.0.tgz",
       "integrity": "sha512-igZpCKV9+E/Mzrpq6YacdTQ0qTiLm85gD6N/IrmyDvQFA4UnU3d5g3m8tMT/6zG/vVkWSU+VxeUyGonL62DuxA==",
+      "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
       },
@@ -4375,6 +4439,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@smithy/uuid/-/uuid-1.1.0.tgz",
       "integrity": "sha512-4aUIteuyxtBUhVdiQqcDhKFitwfd9hqoSDYY2KRXiWtgoWJ9Bmise+KfEPDiVHWeJepvF8xJO9/9+WDIciMFFw==",
+      "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
       },
@@ -4464,7 +4529,6 @@
       "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.76.1.tgz",
       "integrity": "sha512-dYMh9EsTVXZ6WbQ0QmMGIhbXct5+x636tXXaaxUmwjj3kY1jyBTQU8QehxAIfjyRu1mWGV07hoYmTYakkxdSGQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@supabase/auth-js": "2.76.1",
         "@supabase/functions-js": "2.76.1",
@@ -4948,7 +5012,6 @@
       "integrity": "sha512-6mDvHUFSjyT2B2yeNx2nUgMxh9LtOWvkhIU3uePn2I2oyNymUAX1NIsdgviM4CH+JSrp2D2hsMvJOkxY+0wNRA==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.0.2"
       }
@@ -4959,7 +5022,6 @@
       "integrity": "sha512-9KQPoO6mZCi7jcIStSnlOWn2nEF3mNmyr3rIAsGnAbQKYbRLyqmeSc39EVgtxXVia+LMT8j3knZLAZAh+xLmrw==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -5026,7 +5088,6 @@
       "integrity": "sha512-BnOroVl1SgrPLywqxyqdJ4l3S2MsKVLDVxZvjI1Eoe8ev2r3kGDo+PcMihNmDE+6/KjkTubSJnmqGZZjQSBq/g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.46.2",
         "@typescript-eslint/types": "8.46.2",
@@ -5303,7 +5364,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -5683,7 +5743,8 @@
     "node_modules/bowser": {
       "version": "2.12.1",
       "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.12.1.tgz",
-      "integrity": "sha512-z4rE2Gxh7tvshQ4hluIT7XcFrgLIQaw9X3A+kTTRdovCz5PMukm/0QC/BKSYPj3omF5Qfypn9O/c5kgpmvYUCw=="
+      "integrity": "sha512-z4rE2Gxh7tvshQ4hluIT7XcFrgLIQaw9X3A+kTTRdovCz5PMukm/0QC/BKSYPj3omF5Qfypn9O/c5kgpmvYUCw==",
+      "license": "MIT"
     },
     "node_modules/brace-expansion": {
       "version": "1.1.12",
@@ -5729,7 +5790,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.19",
         "caniuse-lite": "^1.0.30001751",
@@ -6793,7 +6853,6 @@
       "integrity": "sha512-t5aPOpmtJcZcz5UJyY2GbvpDlsK5E8JqRqoKtfiKE3cNh437KIqfJr3A3AKf5k64NPx6d0G3dno6XDY05PqPtw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -6967,7 +7026,6 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -7431,6 +7489,7 @@
           "url": "https://github.com/sponsors/NaturalIntelligence"
         }
       ],
+      "license": "MIT",
       "dependencies": {
         "strnum": "^2.1.0"
       },
@@ -10294,7 +10353,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.0.tgz",
       "integrity": "sha512-tmbWg6W31tQLeB5cdIBOicJDJRR2KzXsV7uSK9iNfLWQ5bIZfxuPEHp7M8wiHyHnn0DD1i7w3Zmin0FtkrwoCQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -10304,7 +10362,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.0.tgz",
       "integrity": "sha512-UlbRu4cAiGaIewkPyiRGJk0imDN2T3JjieT6spoL2UeSf5od4n5LB/mQ4ejmxhCFT1tYe8IvaFulzynWovsEFQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -10316,6 +10373,7 @@
       "version": "5.5.3",
       "resolved": "https://registry.npmjs.org/react-easy-crop/-/react-easy-crop-5.5.3.tgz",
       "integrity": "sha512-iKwFTnAsq+IVuyF6N0Q3zjRx9DG1NMySkwWxVfM/xAOeHYH1vhvM+V2kFiq5HOIQGWouITjfltCx54mbDpMpmA==",
+      "license": "MIT",
       "dependencies": {
         "normalize-wheel": "^1.0.1",
         "tslib": "^2.0.1"
@@ -11403,7 +11461,8 @@
           "type": "github",
           "url": "https://github.com/sponsors/NaturalIntelligence"
         }
-      ]
+      ],
+      "license": "MIT"
     },
     "node_modules/styled-jsx": {
       "version": "5.1.6",
@@ -11537,7 +11596,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -11784,7 +11842,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -12335,7 +12392,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "lint": "eslint ."
   },
   "dependencies": {
-    "@aws-sdk/client-s3": "^3.929.0",
+    "@aws-sdk/client-s3": "^3.934.0",
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/modifiers": "^9.0.0",
     "@dnd-kit/sortable": "^10.0.0",


### PR DESCRIPTION
Summary: Adds typed Supabase CRUD helpers for the inventory_units table to centralize DB operations used by the UI and server routes.

Files: inventory.ts
page.tsx (import path fix / restored during rebase)

What’s included:

Insert: createInventoryUnit / createInventoryUnitAdmin
Read: getInventoryUnit, listInventoryUnits
Update: updateInventoryUnit, reconcileInventoryUnit
Delete: deleteInventoryUnit
Types: InventoryUnitRow, NewInventoryUnit, UpdateInventoryUnit

No UI or routes were changed.
No Supabase schema migrations required.
Demo route was added temporarily then removed before committing.