### PR TITLE
feat: add in-app invite acceptance flow via notification bell

### DIFF
--- a/app/protected/(app)/invite-actions.ts
+++ b/app/protected/(app)/invite-actions.ts
@@ -6,9 +6,9 @@ import { redirect } from "next/navigation";
 import { createClient } from "@/lib/supabase/server";
 import { createServiceRoleClient } from "@/lib/supabase/service-role";
 
-export async function acceptInvitation(formData: FormData): Promise<void> {
+export async function acceptInvitation(formData: FormData): Promise<{ error?: string }> {
   const inviteId = formData.get("inviteId") as string | null;
-  if (!inviteId) return;
+  if (!inviteId) return { error: "Invalid invitation." };
 
   // Auth check uses the regular client (cookie-based session).
   const supabase = await createClient();
@@ -26,13 +26,14 @@ export async function acceptInvitation(formData: FormData): Promise<void> {
 
   const { data: invite, error: inviteError } = await admin
     .from("kitchen_invitations")
-    .select("id, kitchen_id, role, expires_at, accepted_at")
+    .select("id, kitchen_id, role, expires_at, accepted_at, email")
     .eq("id", inviteId)
     .maybeSingle();
 
-  if (inviteError || !invite) return;
-  if (invite.accepted_at) return;
-  if (new Date(invite.expires_at) < new Date()) return;
+  if (inviteError || !invite) return { error: "Invitation not found." };
+  if (invite.email.toLowerCase() !== user.email!.toLowerCase()) return { error: "Invitation not found." };
+  if (invite.accepted_at) return { error: "This invitation has already been accepted." };
+  if (new Date(invite.expires_at) < new Date()) return { error: "This invitation has expired." };
 
   const { data: existingMember } = await admin
     .from("kitchen_members")
@@ -42,14 +43,15 @@ export async function acceptInvitation(formData: FormData): Promise<void> {
     .maybeSingle();
 
   if (!existingMember) {
-    await admin.from("kitchen_members").insert({
+    const { error: insertError } = await admin.from("kitchen_members").insert({
       kitchen_id: invite.kitchen_id,
       user_id: user.id,
       role: invite.role ?? "member",
     });
+    if (insertError) return { error: "Failed to join kitchen. Please try again." };
   }
 
-  await admin
+  const { error: updateError } = await admin
     .from("kitchen_invitations")
     .update({
       accepted_at: new Date().toISOString(),
@@ -57,6 +59,9 @@ export async function acceptInvitation(formData: FormData): Promise<void> {
     })
     .eq("id", inviteId);
 
+  if (updateError) return { error: "Failed to confirm invitation. Please try again." };
+
   revalidatePath("/protected");
   revalidatePath("/protected/kitchen-settings");
+  return {};
 }

--- a/app/protected/(app)/invite-actions.ts
+++ b/app/protected/(app)/invite-actions.ts
@@ -1,0 +1,62 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { redirect } from "next/navigation";
+
+import { createClient } from "@/lib/supabase/server";
+import { createServiceRoleClient } from "@/lib/supabase/service-role";
+
+export async function acceptInvitation(formData: FormData): Promise<void> {
+  const inviteId = formData.get("inviteId") as string | null;
+  if (!inviteId) return;
+
+  // Auth check uses the regular client (cookie-based session).
+  const supabase = await createClient();
+  const {
+    data: { user },
+    error: authError,
+  } = await supabase.auth.getUser();
+
+  if (authError || !user) {
+    redirect("/auth/login");
+  }
+
+  // All DB mutations use service role to bypass RLS on kitchen_invitations / kitchen_members.
+  const admin = createServiceRoleClient();
+
+  const { data: invite, error: inviteError } = await admin
+    .from("kitchen_invitations")
+    .select("id, kitchen_id, role, expires_at, accepted_at")
+    .eq("id", inviteId)
+    .maybeSingle();
+
+  if (inviteError || !invite) return;
+  if (invite.accepted_at) return;
+  if (new Date(invite.expires_at) < new Date()) return;
+
+  const { data: existingMember } = await admin
+    .from("kitchen_members")
+    .select("user_id")
+    .eq("kitchen_id", invite.kitchen_id)
+    .eq("user_id", user.id)
+    .maybeSingle();
+
+  if (!existingMember) {
+    await admin.from("kitchen_members").insert({
+      kitchen_id: invite.kitchen_id,
+      user_id: user.id,
+      role: invite.role ?? "member",
+    });
+  }
+
+  await admin
+    .from("kitchen_invitations")
+    .update({
+      accepted_at: new Date().toISOString(),
+      accepted_by: user.id,
+    })
+    .eq("id", inviteId);
+
+  revalidatePath("/protected");
+  revalidatePath("/protected/kitchen-settings");
+}

--- a/app/protected/(app)/kitchen-settings/member-actions.ts
+++ b/app/protected/(app)/kitchen-settings/member-actions.ts
@@ -3,6 +3,7 @@
 import { revalidatePath } from "next/cache";
 
 import { createClient } from "@/lib/supabase/server";
+import { createServiceRoleClient } from "@/lib/supabase/service-role";
 import { ROLE_OPTIONS, type KitchenRole } from "@/components/kitchen-settings/roles";
 
 export type MemberActionResult = { success: true } | { success: false; error: string };
@@ -68,11 +69,9 @@ async function ensureManagePermissions(
   return { role: record.role };
 }
 
-async function countOwners(
-  supabase: Awaited<ReturnType<typeof createClient>>,
-  kitchenId: string,
-): Promise<{ owners: number; error?: string }> {
-  const { data, error } = await supabase
+async function countOwners(kitchenId: string): Promise<{ owners: number; error?: string }> {
+  const admin = createServiceRoleClient();
+  const { data, error } = await admin
     .from("kitchen_members")
     .select("role")
     .eq("kitchen_id", kitchenId);
@@ -281,7 +280,9 @@ export async function updateMemberRole(input: {
       return { success: false, error: "Only owners can update member roles." };
     }
 
-    const { data: targetData, error: targetError } = await supabase
+    const admin = createServiceRoleClient();
+
+    const { data: targetData, error: targetError } = await admin
       .from("kitchen_members")
       .select("role")
       .eq("kitchen_id", kitchenId)
@@ -294,7 +295,7 @@ export async function updateMemberRole(input: {
 
     const currentRole = normalizeRole(targetData.role);
 
-    const { owners, error: ownersError } = await countOwners(supabase, kitchenId);
+    const { owners, error: ownersError } = await countOwners(kitchenId);
     if (ownersError) {
       return { success: false, error: ownersError };
     }
@@ -303,7 +304,7 @@ export async function updateMemberRole(input: {
       return { success: false, error: "You need another owner before demoting this one." };
     }
 
-    const { error: updateError } = await supabase
+    const { error: updateError } = await admin
       .from("kitchen_members")
       .update({ role: targetRole })
       .eq("kitchen_id", kitchenId)
@@ -352,7 +353,9 @@ export async function removeMember(input: {
       return { success: false, error: permissionError ?? "Insufficient permissions." };
     }
 
-    const { data: targetData, error: targetError } = await supabase
+    const admin = createServiceRoleClient();
+
+    const { data: targetData, error: targetError } = await admin
       .from("kitchen_members")
       .select("role")
       .eq("kitchen_id", kitchenId)
@@ -369,7 +372,7 @@ export async function removeMember(input: {
       return { success: false, error: "Only owners can remove another owner." };
     }
 
-    const { owners, error: ownersError } = await countOwners(supabase, kitchenId);
+    const { owners, error: ownersError } = await countOwners(kitchenId);
     if (ownersError) {
       return { success: false, error: ownersError };
     }
@@ -382,7 +385,7 @@ export async function removeMember(input: {
       return { success: false, error: "Add another owner before leaving this kitchen." };
     }
 
-    const { error: deleteError } = await supabase
+    const { error: deleteError } = await admin
       .from("kitchen_members")
       .delete()
       .eq("kitchen_id", kitchenId)

--- a/app/protected/(app)/layout.tsx
+++ b/app/protected/(app)/layout.tsx
@@ -2,6 +2,7 @@ import type { ReactNode } from "react";
 import { cookies } from "next/headers";
 import { NotificationBell } from "@/components/navigation/notification-bell";
 import { resolveKitchen } from "@/app/protected/_lib/resolve-kitchen";
+import { createServiceRoleClient } from "@/lib/supabase/service-role";
 import { AppSidebar } from "@/components/navigation/app-sidebar";
 import type { NavMainItem } from "@/components/navigation/nav-main";
 import type { NavUserData } from "@/components/navigation/nav-user";
@@ -24,6 +25,27 @@ export default async function ProtectedAppLayout({
     kitchen,
     user,
   } = kitchenSnapshot;
+
+  // Load pending kitchen invitations for the current user (service role bypasses RLS on kitchens).
+  type PendingInvite = { id: string; kitchenId: string; kitchenName: string; role: string };
+  let pendingInvites: PendingInvite[] = [];
+  if (user.email) {
+    const admin = createServiceRoleClient();
+    const { data } = await admin
+      .from("kitchen_invitations")
+      .select("id, kitchen_id, role, kitchens(name)")
+      .eq("email", user.email)
+      .is("accepted_at", null)
+      .gt("expires_at", new Date().toISOString());
+    if (data) {
+      pendingInvites = data.map((row) => ({
+        id: row.id,
+        kitchenId: row.kitchen_id,
+        kitchenName: (row.kitchens as unknown as { name: string } | null)?.name ?? "Unknown kitchen",
+        role: row.role ?? "member",
+      }));
+    }
+  }
 
   const kitchenMeta =
     typeof kitchen.memberCount === "number"
@@ -94,7 +116,7 @@ export default async function ProtectedAppLayout({
 
           {/* Right Section: The New Notification Bell */}
           <div className="flex items-center gap-2">
-            <NotificationBell />
+            <NotificationBell pendingInvites={pendingInvites} />
           </div>
         </header>
 

--- a/components/navigation/notification-bell.tsx
+++ b/components/navigation/notification-bell.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { useTransition } from "react";
+import { useRouter } from "next/navigation";
 import { Bell } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import {
@@ -10,49 +12,80 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import { acceptInvitation } from "@/app/protected/(app)/invite-actions";
 
-export function NotificationBell() {
-  // ****** #LATER WE CAN FETCH REAL NOTIFICATIONS HERE# ****** 
-  const hasUnread = true; 
+type PendingInvite = {
+  id: string;
+  kitchenId: string;
+  kitchenName: string;
+  role: string;
+};
+
+type NotificationBellProps = {
+  pendingInvites?: PendingInvite[];
+};
+
+export function NotificationBell({ pendingInvites = [] }: NotificationBellProps) {
+  const router = useRouter();
+  const [isPending, startTransition] = useTransition();
+  const hasUnread = pendingInvites.length > 0;
+
+  const handleAccept = (inviteId: string) => {
+    const formData = new FormData();
+    formData.set("inviteId", inviteId);
+    startTransition(async () => {
+      await acceptInvitation(formData);
+      router.refresh();
+    });
+  };
 
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
-        <Button 
-            variant="ghost" 
-            size="icon" 
-            // 'cursor-pointer' ensures the hand icon appears on hover
-            className="relative h-8 w-8 focus-visible:ring-0 focus-visible:ring-offset-0 data-[state=open]:bg-accent cursor-pointer"
+        <Button
+          variant="ghost"
+          size="icon"
+          className="relative h-8 w-8 focus-visible:ring-0 focus-visible:ring-offset-0 data-[state=open]:bg-accent cursor-pointer"
         >
           <Bell className="h-5 w-5 text-muted-foreground hover:text-foreground transition-colors" />
-          
-          {/* Red Dot for Unread Messages */}
           {hasUnread && (
             <span className="absolute top-1.5 right-1.5 h-2 w-2 rounded-full bg-red-600 border-2 border-background" />
           )}
           <span className="sr-only">Toggle notifications</span>
         </Button>
       </DropdownMenuTrigger>
-      
+
       <DropdownMenuContent align="end" className="w-80">
         <DropdownMenuLabel>Notifications</DropdownMenuLabel>
         <DropdownMenuSeparator />
-        
-        {/* Mock Notifications */}
-        <DropdownMenuItem className="cursor-pointer flex flex-col items-start gap-1 p-3">
-            <span className="font-medium text-sm">Milk is expiring!</span>
-            <span className="text-xs text-muted-foreground">Whole Milk expires in 2 days.</span>
-        </DropdownMenuItem>
-        
-        <DropdownMenuItem className="cursor-pointer flex flex-col items-start gap-1 p-3">
-            <span className="font-medium text-sm">New Recipe Found</span>
-            <span className="text-xs text-muted-foreground">Based on your leftover chicken.</span>
-        </DropdownMenuItem>
-        
-        <DropdownMenuSeparator />
-        <DropdownMenuItem className="cursor-pointer justify-center text-primary font-medium">
-          View all notifications
-        </DropdownMenuItem>
+
+        {pendingInvites.length === 0 ? (
+          <DropdownMenuItem disabled className="text-sm text-muted-foreground justify-center py-4">
+            No new notifications
+          </DropdownMenuItem>
+        ) : (
+          pendingInvites.map((invite) => (
+            <DropdownMenuItem key={invite.id} asChild className="p-0 focus:bg-transparent">
+              <div className="flex flex-col items-start gap-2 p-3 w-full">
+                <div className="flex flex-col gap-0.5">
+                  <span className="font-medium text-sm">Kitchen invitation</span>
+                  <span className="text-xs text-muted-foreground">
+                    You&apos;ve been invited to join{" "}
+                    <span className="font-medium text-foreground">{invite.kitchenName}</span> as {invite.role}.
+                  </span>
+                </div>
+                <Button
+                  size="sm"
+                  className="h-7 text-xs"
+                  disabled={isPending}
+                  onClick={() => handleAccept(invite.id)}
+                >
+                  {isPending ? "Joining…" : "Accept"}
+                </Button>
+              </div>
+            </DropdownMenuItem>
+          ))
+        )}
       </DropdownMenuContent>
     </DropdownMenu>
   );

--- a/components/navigation/notification-bell.tsx
+++ b/components/navigation/notification-bell.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import { useTransition } from "react";
-import { useRouter } from "next/navigation";
+import { useState } from "react";
 import { Bell } from "lucide-react";
+import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import {
   DropdownMenu,
@@ -26,17 +26,22 @@ type NotificationBellProps = {
 };
 
 export function NotificationBell({ pendingInvites = [] }: NotificationBellProps) {
-  const router = useRouter();
-  const [isPending, startTransition] = useTransition();
+  const [pendingIds, setPendingIds] = useState<Set<string>>(new Set());
   const hasUnread = pendingInvites.length > 0;
 
-  const handleAccept = (inviteId: string) => {
+  const handleAccept = async (inviteId: string) => {
+    setPendingIds((prev) => new Set(prev).add(inviteId));
     const formData = new FormData();
     formData.set("inviteId", inviteId);
-    startTransition(async () => {
-      await acceptInvitation(formData);
-      router.refresh();
+    const result = await acceptInvitation(formData);
+    setPendingIds((prev) => {
+      const next = new Set(prev);
+      next.delete(inviteId);
+      return next;
     });
+    if (result.error) {
+      toast.error(result.error);
+    }
   };
 
   return (
@@ -77,10 +82,10 @@ export function NotificationBell({ pendingInvites = [] }: NotificationBellProps)
                 <Button
                   size="sm"
                   className="h-7 text-xs"
-                  disabled={isPending}
+                  disabled={pendingIds.has(invite.id)}
                   onClick={() => handleAccept(invite.id)}
                 >
-                  {isPending ? "Joining…" : "Accept"}
+                  {pendingIds.has(invite.id) ? "Joining…" : "Accept"}
                 </Button>
               </div>
             </DropdownMenuItem>

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.


### PR DESCRIPTION
Summary:
- Added end-to-end kitchen invite acceptance flow via the in-app notification bell
- Invited users see a notification with the kitchen name and role, and can accept with one click
- Invite state is persisted correctly (accepted_at, accepted_by) and membership is created on acceptance
- Fixed removeMember and updateMemberRole in kitchen settings which were silently failing due to RLS

How it works:
1. Kitchen owner opens Kitchen Settings → Manage Members and clicks "Invite Member", entering the invitee's email
2. A kitchen_invitations record is created with a role, expiry, and token
3. The invitee logs in and sees a red dot on the notification bell in the header
4. Opening the bell shows: "You've been invited to join [Kitchen Name] as member" with an Accept button
5. On accept: a kitchen_members record is created, accepted_at is stamped on the invite, and both the bell and the inviter's pending list update immediately

Changes:
- app/protected/(app)/invite-actions.ts — new server action handling invite validation, membership creation, and state transition
- app/protected/(app)/layout.tsx — queries pending invites for the current user and passes them to NotificationBell
- components/navigation/notification-bell.tsx — replaced placeholder mock data with real invite notifications and accept flow
- app/protected/(app)/kitchen-settings/member-actions.ts — fixed removeMember and updateMemberRole to use service role client so owners can manage other users' memberships (was returning "couldn't find member" error)
